### PR TITLE
Remove taint checking (ruby 3.2.0 compat)

### DIFF
--- a/ext/wapiti/tools.c
+++ b/ext/wapiti/tools.c
@@ -44,10 +44,6 @@ FILE *ufopen(VALUE path, const char *mode) {
   FILE *file = (FILE*)0;
   Check_Type(path, T_STRING);
 
-  if (rb_obj_tainted(path)) {
-    fatal("failed to open file from tainted string '%s'", StringValueCStr(path));
-  }
-
   if (!(file = fopen(StringValueCStr(path), mode))) {
     pfatal("failed to open file '%s'", StringValueCStr(path));
   }

--- a/lib/wapiti/dataset.rb
+++ b/lib/wapiti/dataset.rb
@@ -39,9 +39,6 @@ module Wapiti
       end
 
       def open(path, format: File.extname(path), **opts)
-        raise ArgumentError,
-          "cannot open dataset from tainted path: '#{path}'" if path.tainted?
-
         input = File.read(path, encoding: 'utf-8')
         case format.downcase
         when '.xml', 'xml'
@@ -141,9 +138,6 @@ module Wapiti
     end
 
     def save(path, format: File.extname(path), **opts)
-      raise ArgumentError,
-        "cannot write dataset to tainted path: '#{path}'" if path.tainted?
-
       output = case format.downcase
         when '.txt', 'txt'
           to_s(**opts)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec::Matchers.define :be_valid_model_file do
 end
 
 module Fixtures
-  FIXTURES = File.expand_path('../fixtures', __FILE__).untaint
+  FIXTURES = File.expand_path('../fixtures', __FILE__)
 
   def fixture(name)
     File.join FIXTURES, name


### PR DESCRIPTION
This change removes taint checking, which has been deprecated since Ruby 2.7 and has no effect.

Ruby 3.2.0 completely removes taint support, so this gem currently fails to compile under that Ruby version.

I don't think this should have any negative consequences for older Ruby versions.

See this thread for more info and links to similar gems with c extensions having taint checking
removed: https://bugs.ruby-lang.org/issues/16131#note-24